### PR TITLE
Add preconfigured Grafana datasources

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,8 @@ version: '3'
 services:
     influx:
       image: influxdb
-      ports:
-        - "8086:8086"
-        - "8083:8083"
     elasticsearch:
       image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3
-      ports:
-        - "9200:9200"
-        - "9300:9300"
       environment:
         - discovery.type=single-node
     prometheus:
@@ -23,6 +17,8 @@ services:
       image: grafana/grafana
       ports:
         - "3000:3000"
+      volumes:
+        - "./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro"
     python_app:
       build: python
       image: ez-dash/python

--- a/grafana/datasources.yml
+++ b/grafana/datasources.yml
@@ -1,0 +1,17 @@
+apiVersion: 1
+datasources:
+- name: InfluxDB
+  type: influxdb
+  access: proxy
+  url: http://influxdb:8086
+  isDefault: true
+- name: ElasticSearch
+  type: elasticsearch
+  access: proxy
+  url: http://elasticsearch:9200
+  user: elastic
+  password: changeme
+- name: Prometheus
+  type: prometheus
+  access: proxy
+  url: http://prometheus:9090


### PR DESCRIPTION
Preconfigures datasources for InfluxDB, Prometheus, and ElasticSearch.