### PR TITLE
Use configs and change InfluxDB db to ezdash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,15 @@
-version: '3'
+version: "3.5"
+
+configs:
+  grafana_dashboards:
+    file: ./grafana/dashboards.yml
+  grafana_datasources:
+    file: ./grafana/datasources.yml
+  metricbeat:
+    file: ./metricbeat/metricbeat.yml
+  prometheus:
+    file: ./prometheus/prometheus.yml
+
 services:
     influxdb:
       image: influxdb
@@ -8,7 +19,7 @@ services:
         - INFLUXDB_HTTP_AUTH_ENABLED=true
         - INFLUXDB_ADMIN_USER=devnet
         - INFLUXDB_ADMIN_PASSWORD=create
-        - INFLUXDB_DB=tutorial
+        - INFLUXDB_DB=ezdash
     elasticsearch:
       image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3
       environment:
@@ -17,8 +28,10 @@ services:
         - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     metricbeat:
       image: ez-dash/metricbeat
+      configs:
+        - source: metricbeat
+          target: /usr/share/metricbeat/metricbeat.yml
       volumes:
-        - "./metricbeat/metricbeat.yml:/usr/share/metricbeat/metricbeat.yml:ro"
         - "/var/run/docker.sock:/var/run/docker.sock:ro"
       depends_on:
         - elasticsearch
@@ -31,8 +44,9 @@ services:
         - elasticsearch
     prometheus:
       image: prom/prometheus
-      volumes:
-        - "./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro"
+      configs:
+        - source: prometheus
+          target: /etc/prometheus/prometheus.yml
       ports:
         - "9090:9090"
       depends_on:
@@ -41,9 +55,12 @@ services:
       image: grafana/grafana
       ports:
         - "3000:3000"
+      configs:
+        - source: grafana_dashboards
+          target: /etc/grafana/provisioning/dashboards/dashboards.yml
+        - source: grafana_datasources
+          target: /etc/grafana/provisioning/datasources/datasources.yml
       volumes:
-        - "./grafana/datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro"
-        - "./grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro"
         - "./grafana/dashboards:/var/lib/grafana/dashboards:ro"
       environment:
         - GF_INSTALL_PLUGINS=jdbranham-diagram-panel

--- a/grafana/datasources.yml
+++ b/grafana/datasources.yml
@@ -6,7 +6,7 @@ datasources:
   url: http://influxdb:8086
   user: devnet
   password: create
-  database: tutorial
+  database: ezdash
   isDefault: true
 - name: ElasticSearch
   type: elasticsearch

--- a/python/main.py
+++ b/python/main.py
@@ -47,7 +47,7 @@ def stat_creation(i):
 
 
 class InfluxController():
-    def __init__(self, url, dbname='tutorial'):
+    def __init__(self, url, dbname='ezdash'):
         self.dbname = dbname
         self.conn = http.client.HTTPConnection(url)
 


### PR DESCRIPTION
Use configs instead of volume mounts in docker-compose.yml, and changes InfluxDB db to `ezdash` instead of `tutorial`.
Closes #16 