### PR TITLE
Python App Stat Gen

### DIFF
--- a/grafana/dashboards/App Stats.json
+++ b/grafana/dashboards/App Stats.json
@@ -1,20 +1,20 @@
 {
   "__inputs": [
     {
-      "name": "Prometheus",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    },
-    {
       "name": "InfluxDB",
       "label": "InfluxDB",
       "description": "",
       "type": "datasource",
       "pluginId": "influxdb",
       "pluginName": "InfluxDB"
+    },
+    {
+      "name": "Prometheus",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
     }
   ],
   "__requires": [
@@ -77,22 +77,22 @@
         "rgba(237, 129, 40, 0.89)",
         "#d44a3a"
       ],
-      "datasource": "Prometheus",
+      "datasource": "InfluxDB",
       "format": "none",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,
-        "show": false,
+        "show": true,
         "thresholdLabels": false,
         "thresholdMarkers": true
       },
       "gridPos": {
         "h": 9,
-        "w": 6,
+        "w": 12,
         "x": 0,
         "y": 0
       },
-      "id": 10,
+      "id": 20,
       "interval": null,
       "links": [],
       "mappingType": 1,
@@ -126,11 +126,9 @@
         "lineColor": "rgb(31, 120, 193)",
         "show": false
       },
-      "tableColumn": "",
+      "tableColumn": "last",
       "targets": [
         {
-          "expr": "python_info",
-          "format": "time_series",
           "groupBy": [
             {
               "params": [
@@ -145,8 +143,7 @@
               "type": "fill"
             }
           ],
-          "intervalFactor": 1,
-          "legendFormat": "{{implementation}}",
+          "measurement": "gauge",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -161,16 +158,15 @@
               },
               {
                 "params": [],
-                "type": "mean"
+                "type": "last"
               }
             ]
           ],
           "tags": []
         }
       ],
-      "thresholds": "",
-      "title": "Implementation",
-      "transparent": false,
+      "thresholds": "50,80",
+      "title": "Gauge Stat (InfluxDB)",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -180,120 +176,7 @@
           "value": "null"
         }
       ],
-      "valueName": "name"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": "Prometheus",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 6,
-        "x": 6,
-        "y": 0
-      },
-      "id": 14,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": false
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "python_info",
-          "format": "time_series",
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "intervalFactor": 1,
-          "legendFormat": "{{version}}",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "mean"
-              }
-            ]
-          ],
-          "tags": []
-        }
-      ],
-      "thresholds": "",
-      "title": "Version",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "name"
+      "valueName": "current"
     },
     {
       "cacheTimeout": null,
@@ -523,43 +406,67 @@
       "valueName": "name"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
       "datasource": "Prometheus",
-      "fill": 1,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
       "gridPos": {
         "h": 9,
-        "w": 12,
+        "w": 6,
         "x": 0,
         "y": 9
       },
-      "id": 8,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
+      "id": 10,
+      "interval": null,
       "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
       "targets": [
         {
-          "expr": "request_processing_seconds_count",
+          "expr": "python_info",
           "format": "time_series",
           "groupBy": [
             {
@@ -576,7 +483,7 @@
             }
           ],
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "{{implementation}}",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -598,41 +505,132 @@
           "tags": []
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "App Stats",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
+      "thresholds": "",
+      "title": "Implementation",
+      "transparent": false,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "name"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 6,
+        "y": 9
+      },
+      "id": 14,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "name": "range to text",
+          "value": 2
         }
-      ]
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "python_info",
+          "format": "time_series",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "null"
+              ],
+              "type": "fill"
+            }
+          ],
+          "intervalFactor": 1,
+          "legendFormat": "{{version}}",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": "",
+      "title": "Version",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "name"
     },
     {
       "aliasColors": {},
@@ -671,17 +669,18 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "request_processing_seconds_sum",
+          "expr": "request_processing_seconds_sum / request_processing_seconds_count",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
+          "legendFormat": "",
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "App Stats",
+      "title": "Average Stat Gen (Prometheus)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -776,43 +775,7 @@
               "type": "fill"
             }
           ],
-          "measurement": "stat_1",
-          "orderByTime": "ASC",
-          "policy": "default",
-          "refId": "A",
-          "resultFormat": "time_series",
-          "select": [
-            [
-              {
-                "params": [
-                  "value"
-                ],
-                "type": "field"
-              },
-              {
-                "params": [],
-                "type": "last"
-              }
-            ]
-          ],
-          "tags": []
-        },
-        {
-          "groupBy": [
-            {
-              "params": [
-                "$__interval"
-              ],
-              "type": "time"
-            },
-            {
-              "params": [
-                "null"
-              ],
-              "type": "fill"
-            }
-          ],
-          "measurement": "stat_2",
+          "measurement": "sinwave",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "B",
@@ -837,7 +800,7 @@
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Application Stats Collected (InfluxDB)",
+      "title": "Sinwave (InfluxDB)",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -945,7 +908,7 @@
               "type": "fill"
             }
           ],
-          "measurement": "entries_counter",
+          "measurement": "counter",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -968,7 +931,7 @@
         }
       ],
       "thresholds": "",
-      "title": "Number of Executions",
+      "title": "Number of Executions (InfluxDB)",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -989,7 +952,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {

--- a/grafana/dashboards/App Stats.json
+++ b/grafana/dashboards/App Stats.json
@@ -945,7 +945,7 @@
               "type": "fill"
             }
           ],
-          "measurement": "entriest_counter",
+          "measurement": "entries_counter",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",

--- a/grafana/dashboards/App Stats.json
+++ b/grafana/dashboards/App Stats.json
@@ -658,7 +658,7 @@
       "lines": true,
       "linewidth": 1,
       "links": [],
-      "nullPointMode": "null",
+      "nullPointMode": "connected",
       "percentage": false,
       "pointradius": 5,
       "points": false,

--- a/python/Pipfile
+++ b/python/Pipfile
@@ -4,3 +4,4 @@ verify_ssl = true
 
 [packages]
 prometheus_client = "*"
+requests = "*"

--- a/python/main.py
+++ b/python/main.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+"""Simple Python application which exposes metrics to Prometheus
+and InfluxDB to populate pre-configured dashboards in Grafana.
+"""
 import logging
 import math
 import time

--- a/python/main.py
+++ b/python/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import logging
 import math
 import time

--- a/python/main.py
+++ b/python/main.py
@@ -1,35 +1,35 @@
-from prometheus_client import start_http_server, Summary
+#!/usr/bin/env python3
 import threading
+import logging
 import math
 import time
 import random
 import sys
 import http.client
+import prometheus_client as prometheus
 
-REQUEST_TIME = Summary('request_processing_seconds', 'Time spent processing request')
 
+REQUEST_TIME = prometheus.Summary('request_processing_seconds', 'Time spent processing request')
 
 def main():
-    """
-    Runs all functions required for exposing
-    """
+    """Entry point to example app."""
+    setup_logging(logging.DEBUG)
+    logging.info('Starting Prometheus Server')
+    start_prometheus()
+    logging.info('Starting metrics generation to InfluxDB')
+    start_metrics()
 
-    try:
-        print("Starting Prometheus Server")
-        prometheus_server()
-        print("Starting Influx Server")
-        t = threading.Thread(target=influx_server)
-        t.start()
+def setup_logging(level=logging.INFO):
+    """Setup logging to output to standard out."""
+    logging.basicConfig(level=level)
+    logging.getLogger('urllib3').setLevel(logging.WARNING)
 
-    except KeyboardInterrupt:
-        sys.exit()
+def start_prometheus(port=9091):
+    """Start the Prometheus HTTP server."""
+    prometheus.start_http_server(port)
 
-
-def prometheus_server():
-    start_http_server(9091)
-
-
-def influx_server():
+def start_metrics():
+    """Start generating metrics into InfluxDB."""
     count = 1
     influx_controller = InfluxController('influxdb:8086')
     while True:
@@ -38,13 +38,11 @@ def influx_server():
         count += 1
         time.sleep(1)
 
-
 @REQUEST_TIME.time()
 def stat_creation(i):
     stat_1 = 10 + math.sin(math.radians(i)) * 50
     stat_2 = random.randint(0, 200)
     return stat_1, stat_2
-
 
 class InfluxController():
     def __init__(self, url, dbname='ezdash'):
@@ -58,20 +56,21 @@ class InfluxController():
         self.conn.request("POST", "/write?db={}".format(self.dbname), payload, headers)
         res = self.conn.getresponse()
         data = res.read()
-        # print(res.code)
-        print(data.decode("utf-8"))
+        logging.debug(data.decode("utf-8"))
 
     def format_data(self, key, value):
-        timestamp = int(time.time()) * 1000000000
-        data = "{},host=python value={} {}".format(key, value, timestamp)
-        # print(data)
+        timestamp = int(round(time.time() * 1e9)) # Nanoseconds
+        data = "{key},host=python value={value} {timestamp}".format(
+            key=key,
+            value=value,
+            timestamp=timestamp
+        )
         return data
 
     def send_data(self, stat_1, stat_2, stat_3):
         self.write(self.format_data('stat_1', stat_1))
         self.write(self.format_data('stat_2', stat_2))
         self.write(self.format_data('entriest_counter', stat_3))
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Use requests instead of HTTP client with auth creds instead of static, use kv map for influx insertions, name statistics differently, use separate methods for statistic generation. Add some documentation, use logging instead of print.

@skkumaravel Changed the App Stats dashboard, let me know if you're a fan.